### PR TITLE
ci: fix auto-assign and split workflows

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -1,0 +1,18 @@
+name: auto-assign
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  add-reviews:
+    name: Auto assign reviewers
+    runs-on: ubuntu-22.04
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.1
+        with:
+          configuration-path: ".github/assign/auto_assign.yml"

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -7,10 +7,11 @@ on:
 jobs:
   add-reviews:
     name: Auto assign reviewers
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       pull-requests: write
+      contents: read
 
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,21 +4,21 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   build-and-test:
     name: Build and test
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-
       - name: Build
         run: go build ./...
-
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,9 +9,11 @@ on:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+
     permissions:
       contents: read
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go


### PR DESCRIPTION
Split GitHub Actions into two separate workflows (ci and auto-assign) so reviewer assignment happens instantly without being blocked by tests. Also fixed the triggers for correct pipeline execution and set the proper path to the auto_assign.yml config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline expanded to run validation on pull requests in addition to main-branch pushes; runner and job-level permissions updated for consistency.
  * Added an automated pull-request assignment workflow to streamline reviewer assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->