### PR TITLE
Add the ability to search venues by keyword or intent

### DIFF
--- a/internal/business/handler/business/handler.go
+++ b/internal/business/handler/business/handler.go
@@ -39,6 +39,7 @@ type businessService interface {
 	Rating(ctx context.Context, id int) (float32, error)
 
 	ListNearbyVenues(ctx context.Context, lat, lon float64, skip, limit int) (pagination.Result[entity.OrgUnitWithDistance], error)
+	SearchVenues(ctx context.Context, query string, skip, limit int, tags []string) (pagination.Result[entity.OrgUnit], error)
 }
 
 func RegisterHandlers(
@@ -63,6 +64,7 @@ func RegisterHandlers(
 	r.GET("/posts", h.GetPosts)
 	r.GET("/nearby-boxes", h.ListNearbyBoxes)
 	r.GET("/location-tags", h.listLocationTags)
+	r.GET("/venues/search", h.searchVenues)
 
 	businessPosts := r.Group("/posts").
 		Use(auth).
@@ -90,7 +92,7 @@ func RegisterHandlers(
 	}
 
 	r.GET("/locations/nearby", h.ListNearbyVenues)
-	
+
 	reservations := r.Group("/boxes").
 		Use(auth)
 	{

--- a/internal/business/handler/business/search_venues.go
+++ b/internal/business/handler/business/search_venues.go
@@ -1,0 +1,104 @@
+package business
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	apperror "github.com/ua-academy-projects/share-bite/internal/business/error"
+	"github.com/ua-academy-projects/share-bite/pkg/logger"
+)
+
+type searchVenuesRequest struct {
+	Query string `form:"q"`
+	Tags  string `form:"tags"`
+	Skip  int    `form:"skip"`
+	Limit int    `form:"limit"`
+}
+
+// searchVenues searches venues by keyword and/or tags.
+//
+//	@Summary		Search venues
+//	@Description	Search venues by keyword (`q`) in name/description and optional tags (`tags=tag1,tag2`).
+//	@Tags			venues
+//	@Produce		json
+//	@Param			q		query		string	false	"Keyword for name/description"
+//	@Param			tags	query		string	false	"Comma-separated location tag slugs"
+//	@Param			skip	query		int		false	"Number of items to skip (default: 0)"
+//	@Param			limit	query		int		false	"Items per page (default: 10, max: 100)"
+//	@Success		200		{object}	listResponse
+//	@Failure		400		{object}	errorResponse
+//	@Failure		500		{object}	errorResponse
+//	@Router			/business/venues/search [get]
+func (h *handler) searchVenues(c *gin.Context) {
+	ctx := c.Request.Context()
+	log := logger.FromContext(ctx)
+
+	var req searchVenuesRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid query params"})
+		return
+	}
+
+	if req.Skip < 0 {
+		req.Skip = 0
+	}
+	if req.Limit == 0 {
+		req.Limit = 10
+	}
+	if req.Limit < 0 {
+		req.Limit = 1
+	}
+	if req.Limit > 100 {
+		req.Limit = 100
+	}
+
+	var tags []string
+	if req.Tags != "" {
+		seen := make(map[string]struct{})
+		for _, tag := range strings.Split(req.Tags, ",") {
+			tag = strings.ToLower(strings.TrimSpace(tag))
+			if tag == "" {
+				continue
+			}
+			if _, ok := seen[tag]; ok {
+				continue
+			}
+			seen[tag] = struct{}{}
+			tags = append(tags, tag)
+		}
+	}
+
+	log.Info("search venues", "q", req.Query, "tags", tags, "skip", req.Skip, "limit", req.Limit)
+
+	query := strings.TrimSpace(req.Query)
+	if query == "" && len(tags) == 0 {
+		c.Error(apperror.BadRequest("at least one search filter is required: q or tags"))
+		return
+	}
+
+	result, err := h.service.SearchVenues(ctx, query, req.Skip, req.Limit, tags)
+	if err != nil {
+		log.Error("failed to search venues", "error", err)
+		c.Error(err)
+		return
+	}
+
+	items := make([]listItem, 0, len(result.Items))
+	for _, u := range result.Items {
+		items = append(items, listItem{
+			ID:          u.Id,
+			Name:        u.Name,
+			Avatar:      u.Avatar,
+			Description: u.Description,
+			Latitude:    u.Latitude,
+			Longitude:   u.Longitude,
+			Tags:        normalizeTags(u.Tags),
+		})
+	}
+
+	c.JSON(http.StatusOK, listResponse{
+		Items: items,
+		Total: result.Total,
+	})
+}

--- a/internal/business/handler/business/search_venues_test.go
+++ b/internal/business/handler/business/search_venues_test.go
@@ -1,0 +1,155 @@
+package business
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ua-academy-projects/share-bite/internal/business/entity"
+	apperror "github.com/ua-academy-projects/share-bite/internal/business/error"
+	"github.com/ua-academy-projects/share-bite/internal/business/error/code"
+	"github.com/ua-academy-projects/share-bite/pkg/database/pagination"
+)
+
+type searchVenuesServiceMock struct {
+	businessService
+
+	called   bool
+	gotQuery string
+	gotSkip  int
+	gotLimit int
+	gotTags  []string
+
+	result pagination.Result[entity.OrgUnit]
+	err    error
+}
+
+func (m *searchVenuesServiceMock) SearchVenues(
+	ctx context.Context,
+	query string,
+	skip, limit int,
+	tags []string,
+) (pagination.Result[entity.OrgUnit], error) {
+	m.called = true
+	m.gotQuery = query
+	m.gotSkip = skip
+	m.gotLimit = limit
+	m.gotTags = append([]string(nil), tags...)
+
+	return m.result, m.err
+}
+
+func testBusinessErrorMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+
+		last := c.Errors.Last()
+		if last == nil {
+			return
+		}
+
+		var appErr *apperror.Error
+		if errors.As(last.Err, &appErr) {
+			switch appErr.Code {
+			case code.BadRequest:
+				c.JSON(http.StatusBadRequest, gin.H{"error": appErr.Error()})
+				return
+			case code.Forbidden:
+				c.JSON(http.StatusForbidden, gin.H{"error": appErr.Error()})
+				return
+			case code.NotFound:
+				c.JSON(http.StatusNotFound, gin.H{"error": appErr.Error()})
+				return
+			case code.Unauthorized:
+				c.JSON(http.StatusUnauthorized, gin.H{"error": appErr.Error()})
+				return
+			}
+		}
+
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+	}
+}
+
+func setupSearchVenuesRouter(s businessService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.Use(testBusinessErrorMiddleware())
+
+	RegisterHandlers(r.Group("/"), s, dummyTokenParser{})
+
+	return r
+}
+
+func TestSearchVenues_EmptyFilters_ReturnsBadRequest(t *testing.T) {
+	mock := &searchVenuesServiceMock{}
+	router := setupSearchVenuesRouter(mock)
+
+	req, _ := http.NewRequest(http.MethodGet, "/venues/search", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d, body: %s", w.Code, w.Body.String())
+	}
+
+	if mock.called {
+		t.Fatalf("service should not be called when q and tags are empty")
+	}
+}
+
+func TestSearchVenues_TagsAreNormalizedAndDeduplicated(t *testing.T) {
+	mock := &searchVenuesServiceMock{
+		result: pagination.Result[entity.OrgUnit]{
+			Items: []entity.OrgUnit{},
+			Total: 0,
+		},
+	}
+	router := setupSearchVenuesRouter(mock)
+
+	req, _ := http.NewRequest(http.MethodGet, "/venues/search?tags=%20Vegan%20,vegan,ROMANTIC", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d, body: %s", w.Code, w.Body.String())
+	}
+
+	want := []string{"vegan", "romantic"}
+	if !reflect.DeepEqual(mock.gotTags, want) {
+		t.Fatalf("expected tags %v, got %v", want, mock.gotTags)
+	}
+}
+
+func TestSearchVenues_DefaultPaginationApplied(t *testing.T) {
+	mock := &searchVenuesServiceMock{
+		result: pagination.Result[entity.OrgUnit]{
+			Items: []entity.OrgUnit{},
+			Total: 0,
+		},
+	}
+	router := setupSearchVenuesRouter(mock)
+
+	req, _ := http.NewRequest(http.MethodGet, "/venues/search?q=dinner", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d, body: %s", w.Code, w.Body.String())
+	}
+
+	if mock.gotSkip != 0 {
+		t.Fatalf("expected skip=0, got %d", mock.gotSkip)
+	}
+	if mock.gotLimit != 10 {
+		t.Fatalf("expected limit=10, got %d", mock.gotLimit)
+	}
+	if mock.gotQuery != "dinner" {
+		t.Fatalf("expected query=dinner, got %q", mock.gotQuery)
+	}
+}

--- a/internal/business/repository/business/org_unit.go
+++ b/internal/business/repository/business/org_unit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/lib/pq"
 
@@ -368,4 +369,67 @@ func (r *Repository) ListNearbyVenues(ctx context.Context, lat, lon float64, off
 	}
 
 	return pagination.List(ctx, r.db.DB(), "business_repository.ListNearbyVenues", p, scanner)
+}
+
+func (r *Repository) SearchVenues(ctx context.Context, query string, offset, limit int, tags []string) (pagination.Result[entity.OrgUnit], error) {
+	const op = "repository.business.SearchVenues"
+
+	where := "profile_type = 'VENUE'"
+	args := make([]any, 0)
+
+	query = strings.TrimSpace(query)
+	if query != "" {
+		args = append(args, "%"+query+"%")
+		p := len(args)
+		where += fmt.Sprintf(" AND (name ILIKE $%d OR COALESCE(description, '') ILIKE $%d)", p, p)
+	}
+
+	if len(tags) > 0 {
+		args = append(args, pq.Array(tags))
+		p := len(args)
+		where += fmt.Sprintf(`
+		AND EXISTS (
+			SELECT 1
+			FROM business.org_unit_tags ot
+			JOIN business.location_tags lt ON lt.id = ot.tag_id
+			WHERE ot.org_unit_id = business.org_units.id
+			  AND lt.slug = ANY($%d)
+		)`, p)
+	}
+
+	units, err := pagination.List(ctx, r.db.DB(), "business_repository.SearchVenues",
+		pagination.Params{
+			Table:   "business.org_units",
+			Columns: "id, org_account_id, profile_type, name, avatar, banner, description, parent_id, latitude, longitude",
+			Where:   where,
+			OrderBy: "id",
+			Args:    args,
+			Offset:  offset,
+			Limit:   limit,
+		},
+		func(rows pgx.Rows) (entity.OrgUnit, error) {
+			var ou OrgUnit
+			err := rows.Scan(
+				&ou.Id,
+				&ou.OrgAccountId,
+				&ou.ProfileType,
+				&ou.Name,
+				&ou.Avatar,
+				&ou.Banner,
+				&ou.Description,
+				&ou.ParentId,
+				&ou.Latitude,
+				&ou.Longitude,
+			)
+			if err != nil {
+				return entity.OrgUnit{}, fmt.Errorf("%s: %w", op, err)
+			}
+			return ou.ToEntity(), nil
+		},
+	)
+	if err != nil {
+		return pagination.Result[entity.OrgUnit]{}, fmt.Errorf("%s: %w", op, err)
+	}
+
+	return units, nil
 }

--- a/internal/business/service/business/org_unit.go
+++ b/internal/business/service/business/org_unit.go
@@ -100,3 +100,32 @@ func (s *service) ListLocationTags(ctx context.Context) ([]entity.LocationTag, e
 
 	return tags, nil
 }
+
+func (s *service) SearchVenues(ctx context.Context, query string, skip, limit int, tags []string) (pagination.Result[entity.OrgUnit], error) {
+	const op = "service.business.SearchVenues"
+
+	result, err := s.businessRepo.SearchVenues(ctx, query, skip, limit, tags)
+	if err != nil {
+		return pagination.Result[entity.OrgUnit]{}, fmt.Errorf("%s: %w", op, err)
+	}
+
+	if len(result.Items) == 0 {
+		return result, nil
+	}
+
+	ids := make([]int, 0, len(result.Items))
+	for _, item := range result.Items {
+		ids = append(ids, item.Id)
+	}
+
+	tagsByOrgUnitID, err := s.businessRepo.GetOrgUnitTagsByOrgUnitID(ctx, ids)
+	if err != nil {
+		return pagination.Result[entity.OrgUnit]{}, fmt.Errorf("%s: get org unit tags: %w", op, err)
+	}
+
+	for i := range result.Items {
+		result.Items[i].Tags = tagsByOrgUnitID[result.Items[i].Id]
+	}
+
+	return result, nil
+}

--- a/internal/business/service/business/service.go
+++ b/internal/business/service/business/service.go
@@ -44,6 +44,7 @@ type businessRepository interface {
 	GetVenuesByIDs(ctx context.Context, ids []int) ([]entity.OrgUnit, error)
 	GetVenueRating(ctx context.Context, venueID int) (float32, error)
 	ListNearbyVenues(ctx context.Context, lat, lon float64, offset, limit int) (pagination.Result[entity.OrgUnitWithDistance], error)
+	SearchVenues(ctx context.Context, query string, offset, limit int, tags []string) (pagination.Result[entity.OrgUnit], error)
 }
 
 type service struct {


### PR DESCRIPTION
intent обробляється на UI через predefined mappings, backend виконує keyword+tags search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added `GET /venues/search` endpoint enabling users to search venues by text query and filter by tags
* Supports pagination with configurable skip and limit parameters (default limit: 10, maximum: 100)
* Search requires at least one filter criteria (query text or tags) to be provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->