### PR TITLE
feat(collection): add venue validation via business api

### DIFF
--- a/internal/guest/error/error.go
+++ b/internal/guest/error/error.go
@@ -85,7 +85,7 @@ func Internal(msg string) *Error {
 }
 
 func VenueNotFoundID(venueID int64) *Error {
-	msg := fmt.Sprintf("venue with id %q was not found", venueID)
+	msg := fmt.Sprintf("venue with id %d was not found", venueID)
 	return newError(code.NotFound, msg)
 }
 

--- a/internal/guest/handler/collection/add_venue.go
+++ b/internal/guest/handler/collection/add_venue.go
@@ -11,6 +11,7 @@ import (
 
 // @Summary		Add a venue to a collection
 // @Description	Adds a specific venue to an existing collection.
+// @Description	Validates if the venue exists via business API before adding.
 // @Description	Fails if the collection is full (limit is 100 venues),
 // @Description	if the venue is already in the collection, or if the user does not own it.
 //
@@ -26,9 +27,10 @@ import (
 // @Failure		400				{object}	response.ErrorResponse		"Invalid path parameters, or collection is full (limit is 100 venues)"
 // @Failure		401				{object}	response.AuthErrorResponse	"Unauthorized: Missing or invalid token"
 // @Failure		403				{object}	response.ErrorResponse		"Forbidden: Customer profile not found or user does not own this collection"
-// @Failure		404				{object}	response.ErrorResponse		"Not Found: Collection not found"
+// @Failure		404				{object}	response.ErrorResponse		"Not Found: Collection not found, or Venue not found in business API"
 // @Failure		409				{object}	response.ErrorResponse		"Conflict: Venue is already in the collection"
 // @Failure		500				{object}	response.ErrorResponse		"Internal server error"
+// @Failure		502				{object}	response.ErrorResponse		"Bad Gateway: Upstream business API error"
 //
 // @Router			/collections/{collectionId}/venues/{venueId} [post]
 func (h *handler) addVenue(c *gin.Context) {

--- a/internal/guest/handler/collection/add_venue_test.go
+++ b/internal/guest/handler/collection/add_venue_test.go
@@ -124,7 +124,7 @@ func TestAddVenue(t *testing.T) {
 			wantBody: response.ErrorResponse{Message: apperror.ErrVenueAlreadyInCollection.Error()},
 		},
 		{
-			name:         "service returns not found",
+			name:         "service returns collection not found",
 			collectionID: collectionID,
 			venueID:      venueIDStr,
 			customerID:   customerID,
@@ -136,6 +136,20 @@ func TestAddVenue(t *testing.T) {
 			},
 			wantCode: http.StatusNotFound,
 			wantBody: response.ErrorResponse{Message: apperror.CollectionNotFoundID(collectionID).Error()},
+		},
+		{
+			name:         "service returns venue not found",
+			collectionID: collectionID,
+			venueID:      venueIDStr,
+			customerID:   customerID,
+			mockFn: func(s *mockCollectionService) {
+				err := apperror.VenueNotFoundID(venueID)
+				s.On("AddVenue", mock.Anything, collectionID, customerID, venueID).
+					Return(err).
+					Once()
+			},
+			wantCode: http.StatusNotFound,
+			wantBody: response.ErrorResponse{Message: apperror.VenueNotFoundID(venueID).Error()},
 		},
 		{
 			name:         "service returns unknown error",

--- a/internal/guest/handler/collection/remove_venue.go
+++ b/internal/guest/handler/collection/remove_venue.go
@@ -12,6 +12,7 @@ import (
 
 // @Summary		Remove a venue from a collection
 // @Description	Removes a specific venue from an existing collection.
+// @Description	Validates if the venue exists via business API before removing.
 // @Description	Fails if the user does not own the collection or if the venue is not in the collection.
 //
 // @Tags			collections
@@ -26,8 +27,9 @@ import (
 // @Failure		400				{object}	response.ErrorResponse		"Invalid path parameters"
 // @Failure		401				{object}	response.AuthErrorResponse	"Unauthorized: Missing or invalid token"
 // @Failure		403				{object}	response.ErrorResponse		"Forbidden: Customer profile not found or user does not own this collection"
-// @Failure		404				{object}	response.ErrorResponse		"Not Found: Collection not found or venue is not in the collection"
+// @Failure		404				{object}	response.ErrorResponse		"Not Found: Collection not found, venue is not in the collection, or venue unknown in business API"
 // @Failure		500				{object}	response.ErrorResponse		"Internal server error"
+// @Failure		502				{object}	response.ErrorResponse		"Bad Gateway: Upstream business API error"
 //
 // @Router			/collections/{collectionId}/venues/{venueId} [delete]
 func (h *handler) removeVenue(c *gin.Context) {

--- a/internal/guest/handler/collection/remove_venue_test.go
+++ b/internal/guest/handler/collection/remove_venue_test.go
@@ -100,6 +100,32 @@ func TestRemoveVenue(t *testing.T) {
 			wantBody:     response.ErrorResponse{Message: internalErrMsg},
 		},
 		{
+			name:         "service returns venue not found (from business API)",
+			collectionID: collectionID,
+			venueIDPath:  venueIDStr,
+			customerID:   customerID,
+			mockFn: func(s *mockCollectionService) {
+				s.On("RemoveVenue", mock.Anything, collectionID, customerID, venueID).
+					Return(apperror.VenueNotFoundID(venueID)).
+					Once()
+			},
+			wantCode: http.StatusNotFound,
+			wantBody: response.ErrorResponse{Message: apperror.VenueNotFoundID(venueID).Error()},
+		},
+		{
+			name:         "service returns upstream bad gateway error",
+			collectionID: collectionID,
+			venueIDPath:  venueIDStr,
+			customerID:   customerID,
+			mockFn: func(s *mockCollectionService) {
+				s.On("RemoveVenue", mock.Anything, collectionID, customerID, venueID).
+					Return(apperror.ErrUpstreamError).
+					Once()
+			},
+			wantCode: http.StatusBadGateway,
+			wantBody: response.ErrorResponse{Message: apperror.ErrUpstreamError.Error()},
+		},
+		{
 			name:         "service venue not found in collection",
 			collectionID: collectionID,
 			venueIDPath:  venueIDStr,

--- a/internal/guest/service/collection/add_venue.go
+++ b/internal/guest/service/collection/add_venue.go
@@ -13,7 +13,13 @@ func (s *service) AddVenue(
 	customerID string,
 	venueID int64,
 ) error {
-	// TODO: check whether this venue exists
+	exists, err := s.businessClient.CheckExists(ctx, venueID)
+	if err != nil {
+		return fmt.Errorf("check whether the venue exists: %w", err)
+	}
+	if !exists {
+		return apperror.VenueNotFoundID(venueID)
+	}
 
 	if txErr := s.txManager.ReadCommitted(ctx, func(ctx context.Context) error {
 		collection, err := s.collectionRepo.GetCollectionForUpdate(ctx, collectionID)

--- a/internal/guest/service/collection/add_venue_test.go
+++ b/internal/guest/service/collection/add_venue_test.go
@@ -31,7 +31,7 @@ func TestAddVenue(t *testing.T) {
 		customerID   string
 		venueID      int64
 
-		mockFn func(repo *mockCollectionRepository, tx *mockTxManager)
+		mockFn func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient)
 
 		wantErr error
 	}{
@@ -40,7 +40,8 @@ func TestAddVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).Return(
@@ -62,7 +63,8 @@ func TestAddVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).Return(
@@ -84,11 +86,37 @@ func TestAddVenue(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name:         "error - business client check exists fails",
+			collectionID: collectionID,
+			customerID:   customerID,
+			venueID:      venueID,
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).
+					Return(false, apperror.ErrUpstreamError).
+					Once()
+			},
+			wantErr: apperror.ErrUpstreamError,
+		},
+		{
+			name:         "error - venue does not exist",
+			collectionID: collectionID,
+			customerID:   customerID,
+			venueID:      venueID,
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).
+					Return(false, nil).
+					Once()
+			},
+			wantErr: apperror.VenueNotFoundID(venueID),
+		},
+		{
 			name:         "error - collection not found (outsider)",
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
+
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).Return(
@@ -108,7 +136,9 @@ func TestAddVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
+
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).Return(
@@ -126,7 +156,9 @@ func TestAddVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
+
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -139,7 +171,9 @@ func TestAddVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
+
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).Return(
@@ -157,7 +191,9 @@ func TestAddVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
+
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).Return(
@@ -177,7 +213,9 @@ func TestAddVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
+
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).Return(
@@ -199,7 +237,9 @@ func TestAddVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
+
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).Return(
@@ -218,7 +258,9 @@ func TestAddVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
+
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).Return(
@@ -240,7 +282,7 @@ func TestAddVenue(t *testing.T) {
 			businessClient := new(mockBusinessClient)
 			svc := New(repo, nil, txManager, businessClient)
 
-			tt.mockFn(repo, txManager)
+			tt.mockFn(repo, txManager, businessClient)
 
 			err := svc.AddVenue(context.Background(), tt.collectionID, tt.customerID, tt.venueID)
 

--- a/internal/guest/service/collection/mock_test.go
+++ b/internal/guest/service/collection/mock_test.go
@@ -177,6 +177,11 @@ func (m *mockBusinessClient) ListVenuesByIDs(ctx context.Context, venueIDs []int
 	return nil, args.Error(1)
 }
 
+func (m *mockBusinessClient) CheckExists(ctx context.Context, venueID int64) (bool, error) {
+	args := m.Called(ctx, venueID)
+	return args.Bool(0), args.Error(1)
+}
+
 type mockTxManager struct {
 	mock.Mock
 }

--- a/internal/guest/service/collection/remove_venue.go
+++ b/internal/guest/service/collection/remove_venue.go
@@ -13,8 +13,6 @@ func (s *service) RemoveVenue(
 	customerID string,
 	venueID int64,
 ) error {
-	// TODO: check whether this venue exists
-
 	if txErr := s.txManager.ReadCommitted(ctx, func(ctx context.Context) error {
 		collection, err := s.collectionRepo.GetCollectionForUpdate(ctx, collectionID)
 		if err != nil {

--- a/internal/guest/service/collection/remove_venue.go
+++ b/internal/guest/service/collection/remove_venue.go
@@ -13,6 +13,14 @@ func (s *service) RemoveVenue(
 	customerID string,
 	venueID int64,
 ) error {
+	exists, err := s.businessClient.CheckExists(ctx, venueID)
+	if err != nil {
+		return fmt.Errorf("check whether the venue exists: %w", err)
+	}
+	if !exists {
+		return apperror.VenueNotFoundID(venueID)
+	}
+
 	if txErr := s.txManager.ReadCommitted(ctx, func(ctx context.Context) error {
 		collection, err := s.collectionRepo.GetCollectionForUpdate(ctx, collectionID)
 		if err != nil {

--- a/internal/guest/service/collection/remove_venue_test.go
+++ b/internal/guest/service/collection/remove_venue_test.go
@@ -31,7 +31,7 @@ func TestRemoveVenue(t *testing.T) {
 		customerID   string
 		venueID      int64
 
-		mockFn func(repo *mockCollectionRepository, tx *mockTxManager)
+		mockFn func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient)
 
 		wantErr error
 	}{
@@ -40,7 +40,8 @@ func TestRemoveVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -62,7 +63,8 @@ func TestRemoveVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -81,11 +83,36 @@ func TestRemoveVenue(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name:         "error - business client check exists fails",
+			collectionID: collectionID,
+			customerID:   customerID,
+			venueID:      venueID,
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).
+					Return(false, apperror.ErrUpstreamError).
+					Once()
+			},
+			wantErr: apperror.ErrUpstreamError,
+		},
+		{
+			name:         "error - venue does not exist",
+			collectionID: collectionID,
+			customerID:   customerID,
+			venueID:      venueID,
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).
+					Return(false, nil).
+					Once()
+			},
+			wantErr: apperror.VenueNotFoundID(venueID),
+		},
+		{
 			name:         "error - check if collaborator repo fails",
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -100,7 +127,8 @@ func TestRemoveVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -114,7 +142,8 @@ func TestRemoveVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -128,7 +157,8 @@ func TestRemoveVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -145,7 +175,8 @@ func TestRemoveVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -163,7 +194,8 @@ func TestRemoveVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -181,7 +213,8 @@ func TestRemoveVenue(t *testing.T) {
 			collectionID: collectionID,
 			customerID:   customerID,
 			venueID:      venueID,
-			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager) {
+			mockFn: func(repo *mockCollectionRepository, tx *mockTxManager, bc *mockBusinessClient) {
+				bc.On("CheckExists", mock.Anything, venueID).Return(true, nil).Once()
 				tx.On("ReadCommitted", mock.Anything, mock.Anything).Return(nil).Once()
 
 				repo.On("GetCollectionForUpdate", mock.Anything, collectionID).
@@ -209,7 +242,7 @@ func TestRemoveVenue(t *testing.T) {
 			businessClient := new(mockBusinessClient)
 			svc := New(repo, nil, txManager, businessClient)
 
-			tt.mockFn(repo, txManager)
+			tt.mockFn(repo, txManager, businessClient)
 
 			err := svc.RemoveVenue(context.Background(), tt.collectionID, tt.customerID, tt.venueID)
 
@@ -222,6 +255,7 @@ func TestRemoveVenue(t *testing.T) {
 
 			repo.AssertExpectations(t)
 			txManager.AssertExpectations(t)
+			businessClient.AssertExpectations(t)
 		})
 	}
 }

--- a/internal/guest/service/collection/service.go
+++ b/internal/guest/service/collection/service.go
@@ -68,6 +68,7 @@ type customerRepository interface {
 
 type businessClient interface {
 	ListVenuesByIDs(ctx context.Context, venueIDs []int64) (map[int64]entity.Venue, error)
+	CheckExists(ctx context.Context, venueID int64) (bool, error)
 }
 
 type service struct {

--- a/migrations/20260605082235_add_collection_venue_fk.sql
+++ b/migrations/20260605082235_add_collection_venue_fk.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE guest.collection_venues
+ADD CONSTRAINT fk_collection_venues_venue_id
+FOREIGN KEY (venue_id) REFERENCES business.org_units(id) ON DELETE CASCADE;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE guest.collection_venues
+DROP CONSTRAINT IF EXISTS fk_collection_venues_venue_id;
+-- +goose StatementEnd


### PR DESCRIPTION
Closes #221

### Overview
Added venue existence validation via the `business API` before adding or removing it from a collection. This prevents the system from storing or getting stuck with stale data.

### Key Changes
* Integrated the `businessClient.CheckExists` call into the `AddVenue` and `RemoveVenue` service methods.
* Added proper error handling: returns `404` if the venue is not found upstream, and `502` on network/gateway errors.
* Updated Swagger documentation to reflect the new HTTP response statuses.
* Created a new database migration to add an `ON DELETE CASCADE` constraint for `venue_id` in the `collection_venues` table.
* Added and updated unit tests to cover the new validation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added venue existence validation when adding or removing venues from collections
  * Improved error handling with proper HTTP status codes (404 for missing venues, 502 for upstream service failures)

* **Documentation**
  * Updated API documentation to reflect new venue validation behavior and error responses

* **Chores**
  * Enhanced data integrity with database constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->