### PR TITLE
Add admin UI for platform statistics and business verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ docs/k8s/secrets.local.yaml
 
 # generated api clients
 internal/guest/gateway/business/client/
+pkg/gateway/admin/client/
 
 .agent
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-guest build-business build-auth build-migrator build-notifications build-outbox build-lambda
-.PHONY: run-all run-guest run-business run-auth migrate-up
+.PHONY: run-all run-guest run-business run-auth run-notifications run-outbox migrate-up
 .PHONY: test test-cover tidy clean
 .PHONY: docs docs-guest docs-business docs-admin-auth
 .PHONY: generate generate-guest-business-client
@@ -42,6 +42,12 @@ run-business: build-business
 
 run-auth: build-auth
 	./bin/admin-auth-api
+
+run-notifications: build-notifications
+	./bin/notifications-service
+
+run-outbox: build-outbox
+	./bin/outbox-worker
 
 migrate-up: build-migrator
 	./bin/migrator

--- a/build/compose.infra.yaml
+++ b/build/compose.infra.yaml
@@ -68,9 +68,29 @@ services:
       timeout: 5s
       retries: 5
 
+  localstack:
+    image: localstack/localstack:3
+    container_name: share-bite-localstack
+    ports:
+      - "4566:4566"
+    environment:
+      SERVICES: sns,sqs
+      DEFAULT_REGION: us-east-2
+      AWS_DEFAULT_REGION: us-east-2
+    volumes:
+      - localstack-data:/var/lib/localstack
+    networks:
+      - share-bite-net
+    healthcheck:
+      test: ["CMD-SHELL", "awslocal sns list-topics >/dev/null 2>&1 && awslocal sqs list-queues >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
 volumes:
   pg_data:
   pgadmin_data:
+  localstack-data:
   redis-data:
     driver: local
 

--- a/cmd/admin-auth-api/main.go
+++ b/cmd/admin-auth-api/main.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/sony/gobreaker"
 	businessclient "github.com/ua-academy-projects/share-bite/internal/admin-auth/adapter/business"
 	guestclient "github.com/ua-academy-projects/share-bite/internal/admin-auth/adapter/guest"
 	apperr "github.com/ua-academy-projects/share-bite/internal/admin-auth/error"
@@ -17,9 +15,6 @@ import (
 	mcphttp "github.com/ua-academy-projects/share-bite/internal/admin-auth/handler/mcp"
 	"github.com/ua-academy-projects/share-bite/internal/admin-auth/worker"
 	"github.com/ua-academy-projects/share-bite/internal/config/env"
-	"github.com/ua-academy-projects/share-bite/pkg/notification"
-	"github.com/ua-academy-projects/share-bite/pkg/redis"
-	"github.com/ua-academy-projects/share-bite/pkg/resilience"
 	"go.uber.org/zap"
 
 	authhttp "github.com/ua-academy-projects/share-bite/internal/admin-auth/handler/auth"
@@ -62,11 +57,6 @@ func main() {
 		logger.Fatal(ctx, "load google oauth config: ", err)
 	}
 
-	redisCfg, err := env.NewRedisConfig()
-	if err != nil {
-		logger.Fatal(ctx, "load redis config: ", err)
-	}
-
 	router := gin.New()
 	router.Use(gin.Recovery())
 	router.Use(pkgmw.RequestID())
@@ -94,56 +84,6 @@ func main() {
 		client.Close()
 		return nil
 	})
-
-	rdb, err := redis.NewClient(
-		redisCfg.Addr(),
-		redisCfg.Password(),
-		redisCfg.DB(),
-		redisCfg.TLS(),
-	)
-	if err != nil {
-		logger.Fatal(ctx, "new redis client: ", err)
-	}
-	closer.Add(func(ctx context.Context) error {
-		return rdb.Close()
-	})
-
-	notificationResiliencePolicy := resilience.Policy{
-		RetryConfig: resilience.RetryConfig{
-			InitialInterval:     10 * time.Millisecond,
-			RandomizationFactor: 0.2,
-			Multiplier:          2.0,
-			MaxInterval:         200 * time.Millisecond,
-			MaxElapsedTime:      1500 * time.Millisecond,
-		},
-		Breaker: resilience.NewCircuitBreaker(resilience.CircuitBreakerConfig{
-			Name:        "admin-redis-pub",
-			MaxRequests: 1,
-			Interval:    10 * time.Second,
-			Timeout:     5 * time.Second,
-			ReadyToTrip: func(counts gobreaker.Counts) bool {
-				return counts.ConsecutiveFailures >= 20
-			},
-			OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
-				logger.WarnKV(ctx, "redis circuit breaker state changed",
-					"name", name,
-					"from", from.String(),
-					"to", to.String(),
-				)
-			},
-			IsSuccessful: func(err error) bool {
-				if err == nil || errors.Is(err, context.Canceled) {
-					return true
-				}
-				return redis.IsPermanentRedisError(err)
-			},
-		}),
-		RetryNotify: func(err error, nextRetryIn time.Duration) {
-			logger.Debugf(ctx, "redis publish retry scheduled in %v: %v", nextRetryIn, err)
-		},
-	}
-
-	broker := notification.NewBroker(rdb, notification.WithPublishPolicy(notificationResiliencePolicy))
 
 	tokenManager := jwt.NewTokenManager(
 		cfg.JwtToken.AccessTokenSecretKey(),
@@ -176,7 +116,7 @@ func main() {
 	customerClient := guestclient.NewClient(client)
 	businessClient := businessclient.NewClient(client)
 
-	adminSvc := adminsvc.NewService(adminRepo, userRepo, customerClient, businessClient, broker, txManager)
+	adminSvc := adminsvc.NewService(adminRepo, userRepo, customerClient, businessClient, outboxWriter, txManager)
 	adminHandler := adminhttp.NewHandler(adminSvc)
 
 	mcpSvc := mcpsvc.NewMCPPermissionService(adminRepo)

--- a/cmd/outbox-worker/main.go
+++ b/cmd/outbox-worker/main.go
@@ -45,7 +45,10 @@ func main() {
 		logger.Fatal(ctx, "OUTBOX_SNS_TOPIC_ARN is required")
 	}
 
-	snsPub, err := outboxpkg.NewSNSPublisher(ctx, topicArn)
+	// Optional: point SNS at a custom endpoint (e.g. LocalStack) for local dev.
+	snsEndpoint := config.GetSecret("OUTBOX_SNS_ENDPOINT_URL")
+
+	snsPub, err := outboxpkg.NewSNSPublisher(ctx, topicArn, snsEndpoint)
 	if err != nil {
 		logger.Fatal(ctx, "new sns publisher:", err)
 	}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,6 +5,36 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+ * Map the design tokens below into Tailwind's color namespace so shadcn
+ * utilities (bg-popover, bg-muted, text-muted-foreground, border-border, …)
+ * are generated. Uses `inline` + var() so the .dark overrides keep working.
+ */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
 
 :root {
   --background: #F9F7F2;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,8 @@ import { ProfileCreatePage } from "@/pages/guest/UserProfile/ProfileCreatePage";
 import { CreatePost } from "@/pages/guest/CreatePost/CreatePost";
 import { AdminUsersPage } from "@/pages/guest/Admin/AdminUsersPage";
 import { AdminUserDetailPage } from "@/pages/guest/Admin/AdminUserDetailPage";
+import { AdminStatisticsPage } from "@/pages/guest/Admin/AdminStatisticsPage";
+import { AdminPendingBusinessesPage } from "@/pages/guest/Admin/AdminPendingBusinessesPage";
 import { ForbiddenPage } from "@/pages/guest/Forbidden/ForbiddenPage";
 import { isUserRole } from "@/utils/auth";
 
@@ -163,6 +165,22 @@ function App() {
             element={
               <RequireAdmin>
                 <AdminUserDetailPage />
+              </RequireAdmin>
+            }
+          />
+          <Route
+            path="/admin/statistics"
+            element={
+              <RequireAdmin>
+                <AdminStatisticsPage />
+              </RequireAdmin>
+            }
+          />
+          <Route
+            path="/admin/businesses"
+            element={
+              <RequireAdmin>
+                <AdminPendingBusinessesPage />
               </RequireAdmin>
             }
           />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -15,6 +15,10 @@ import type {
   FullUserDetails,
   AdminUsersParams,
   CollectionItem,
+  PlatformStatistics,
+  PaginatedPendingBusinesses,
+  ReviewBusinessStatus,
+  PaginationParams,
 } from "@/types/api";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
@@ -548,6 +552,31 @@ export const apiClient = {
     const res = await apiRoot.patch<{ message: string }>(
       `/admin/users/${id}/role`,
       { role_slug: roleSlug }
+    );
+    return res.data;
+  },
+
+  adminGetStatistics: async () => {
+    const res = await apiRoot.get<PlatformStatistics>("/admin/statistics");
+    return res.data;
+  },
+
+  adminGetPendingBusinesses: async (params: PaginationParams = {}) => {
+    const res = await apiRoot.get<PaginatedPendingBusinesses>(
+      "/admin/businesses/pending",
+      { params }
+    );
+    return res.data;
+  },
+
+  adminReviewBusiness: async (
+    orgUnitId: number,
+    status: ReviewBusinessStatus,
+    comment?: string
+  ) => {
+    const res = await apiRoot.patch<{ message: string }>(
+      `/admin/businesses/${orgUnitId}/review`,
+      { status, ...(comment ? { comment } : {}) }
     );
     return res.data;
   },

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -31,7 +31,7 @@ function mapNotification(raw: Record<string, unknown>): NotificationItem {
     entityID: String(raw.entityID ?? raw.entity_id ?? ""),
     metadata,
     createdAt: String(raw.createdAt ?? raw.created_at ?? new Date().toISOString()),
-    read: Boolean(raw.read),
+    read: Boolean(raw.isRead ?? raw.is_read ?? raw.read),
     message,
   };
 }

--- a/frontend/src/components/Notifications/NotificationBell.tsx
+++ b/frontend/src/components/Notifications/NotificationBell.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
-import { Bell } from "lucide-react";
-import { fetchNotifications } from "@/api/notifications";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Bell, CheckCheck } from "lucide-react";
+import { fetchNotifications, markNotificationsRead } from "@/api/notifications";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -20,6 +20,8 @@ type NotificationBellProps = {
 export function NotificationBell({ variant = "default" }: NotificationBellProps) {
   const token = localStorage.getItem("token");
 
+  const queryClient = useQueryClient();
+
   const { data: notifications = [] } = useQuery({
     queryKey: ["notifications"],
     queryFn: () => fetchNotifications(token!, 20),
@@ -28,7 +30,13 @@ export function NotificationBell({ variant = "default" }: NotificationBellProps)
     enabled: !!token,
   });
 
-  const unreadCount = notifications.filter((n) => !n.read).length;
+  const markRead = useMutation({
+    mutationFn: (ids: string[]) => markNotificationsRead(token!, ids),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["notifications"] }),
+  });
+
+  const unreadIds = notifications.filter((n) => !n.read).map((n) => n.id);
+  const unreadCount = unreadIds.length;
 
   const formatMessage = (n: (typeof notifications)[0]) =>
     n.message ||
@@ -78,9 +86,23 @@ export function NotificationBell({ variant = "default" }: NotificationBellProps)
               Notifications
             </PopoverTitle>
           </div>
-          <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-300">
-            {unreadCount} new
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-300">
+              {unreadCount} new
+            </span>
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                onClick={() => markRead.mutate(unreadIds)}
+                disabled={markRead.isPending}
+                aria-label="Mark all as read"
+                title="Mark all as read"
+                className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 transition-colors hover:text-emerald-700 disabled:opacity-50 dark:text-emerald-300 dark:hover:text-emerald-200"
+              >
+                <CheckCheck className="h-4 w-4" />
+              </button>
+            )}
+          </div>
         </PopoverHeader>
 
         <div className="max-h-80 overflow-y-auto border-t border-gray-200 dark:border-[#2f5e50]">

--- a/frontend/src/components/ui/Sidebar.tsx
+++ b/frontend/src/components/ui/Sidebar.tsx
@@ -183,8 +183,14 @@ export function Sidebar() {
             {isAdminOrModerator() ? (
               <>
                 <NavSection label="Admin" />
-                <NavLink to="/admin" className={linkClass}>
+                <NavLink to="/admin" end className={linkClass}>
                   Admin Users
+                </NavLink>
+                <NavLink to="/admin/statistics" className={linkClass}>
+                  Statistics
+                </NavLink>
+                <NavLink to="/admin/businesses" className={linkClass}>
+                  Verify Businesses
                 </NavLink>
               </>
             ) : null}

--- a/frontend/src/components/ui/Sidebar.tsx
+++ b/frontend/src/components/ui/Sidebar.tsx
@@ -6,6 +6,7 @@ import { NotificationBell } from "@/components/Notifications/NotificationBell";
 import { LogoutDialog } from "@/components/LogoutDialog";
 import { useCurrentCustomer } from "@/hooks/useCurrentCustomer";
 import { useOnboardingStatus } from "@/hooks/useOnboardingStatus";
+import { useRealtimeNotifications } from "@/hooks/useRealtimeNotifications";
 import {
   getBusinessOrgId,
   getTokenRole,
@@ -30,6 +31,7 @@ export function Sidebar() {
   const token = localStorage.getItem("token");
   const { data: customer } = useCurrentCustomer();
   useOnboardingStatus(!!token);
+  useRealtimeNotifications();
   const [logoutOpen, setLogoutOpen] = useState(false);
   const businessOrgId = getBusinessOrgId();
 

--- a/frontend/src/hooks/useRealtimeNotifications.ts
+++ b/frontend/src/hooks/useRealtimeNotifications.ts
@@ -11,9 +11,9 @@ import { buildNotificationsStreamUrl } from "@/api/notifications";
  */
 export function useRealtimeNotifications() {
   const queryClient = useQueryClient();
+  const token = localStorage.getItem("token");
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
     if (!token) return;
 
     let es: EventSource | null = null;
@@ -46,5 +46,5 @@ export function useRealtimeNotifications() {
       if (reconnectTimer) clearTimeout(reconnectTimer);
       es?.close();
     };
-  }, [queryClient]);
+  }, [queryClient, token]);
 }

--- a/frontend/src/hooks/useRealtimeNotifications.ts
+++ b/frontend/src/hooks/useRealtimeNotifications.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { buildNotificationsStreamUrl } from "@/api/notifications";
+
+/**
+ * Opens an SSE connection to the notifications stream and refreshes the
+ * ["notifications"] query cache whenever a new notification is pushed, so the
+ * bell badge and the notifications list update live — no page reload needed.
+ *
+ * Mount once for an authenticated session (e.g. in the Sidebar).
+ */
+export function useRealtimeNotifications() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
+
+    let es: EventSource | null = null;
+    let reconnectTimer: number | null = null;
+    let closed = false;
+
+    const connect = () => {
+      es = new EventSource(buildNotificationsStreamUrl(token));
+
+      // Default ("message") events carry notifications; "ping" heartbeats are
+      // named events and intentionally ignored here.
+      es.onmessage = () => {
+        queryClient.invalidateQueries({ queryKey: ["notifications"] });
+      };
+
+      es.onerror = () => {
+        es?.close();
+        if (closed || reconnectTimer) return;
+        reconnectTimer = window.setTimeout(() => {
+          reconnectTimer = null;
+          connect();
+        }, 5000);
+      };
+    };
+
+    connect();
+
+    return () => {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      es?.close();
+    };
+  }, [queryClient]);
+}

--- a/frontend/src/pages/guest/Admin/AdminPendingBusinessesPage.tsx
+++ b/frontend/src/pages/guest/Admin/AdminPendingBusinessesPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Building2, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Building2, CheckCircle2, Hash, Loader2, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { apiClient } from "@/api/client";
 import type { PendingBusinessListItem } from "@/types/api";
@@ -24,7 +25,19 @@ function businessInitial(name: string) {
   return name.trim().charAt(0).toUpperCase() || "?";
 }
 
+function statusBadgeClass(status: string) {
+  switch (status.toLowerCase()) {
+    case "verified":
+      return "border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300";
+    case "rejected":
+      return "border-red-500/40 bg-red-500/10 text-red-500 dark:text-red-400";
+    default:
+      return "border-[#FFD700]/40 bg-[#FFD700]/10 text-[#FFD700]";
+  }
+}
+
 export function AdminPendingBusinessesPage() {
+  const navigate = useNavigate();
   const [businesses, setBusinesses] = useState<PendingBusinessListItem[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -149,11 +162,22 @@ export function AdminPendingBusinessesPage() {
             return (
               <Card
                 key={business.id}
-                className="rounded-3xl border border-gray-200 bg-white shadow-sm transition-all hover:shadow-lg dark:border-[#2f5e50] dark:bg-[#163d32]"
+                role="button"
+                tabIndex={0}
+                onClick={() => navigate(`/venue/${business.id}`)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    navigate(`/venue/${business.id}`);
+                  }
+                }}
+                aria-label={`Open ${business.name} business page`}
+                className="cursor-pointer overflow-hidden rounded-3xl border border-gray-200 bg-white py-0 shadow-sm ring-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 dark:border-[#2f5e50] dark:bg-[#163d32]"
               >
-                <CardContent className="space-y-4 p-5">
-                  <div className="flex gap-4">
-                    <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-gray-200 bg-[#163d32] text-2xl font-bold text-[#98FF98] dark:border-[#2f5e50]">
+                <CardContent className="flex h-full flex-col p-0">
+                  {/* Identity header */}
+                  <div className="flex items-start gap-4 border-b border-gray-100 bg-gradient-to-br from-emerald-500/[0.07] via-transparent to-transparent p-5 dark:border-[#2f5e50] dark:from-[#98FF98]/[0.06]">
+                    <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-[#163d32] text-2xl font-bold text-[#98FF98] shadow-inner ring-1 ring-emerald-500/20 dark:ring-[#2f5e50]">
                       {business.avatar ? (
                         <img
                           src={business.avatar}
@@ -165,53 +189,86 @@ export function AdminPendingBusinessesPage() {
                       )}
                     </div>
                     <div className="min-w-0 flex-1">
-                      <h3 className="truncate text-lg font-bold text-[#1A3C34] dark:text-white">
-                        {business.name}
-                      </h3>
-                      <p className="mt-1 inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
-                        <Building2 className="h-3.5 w-3.5" />
-                        Org #{business.id}
-                      </p>
+                      <div className="flex items-start justify-between gap-2">
+                        <h3 className="truncate text-xl font-bold leading-tight text-[#1A3C34] dark:text-white">
+                          {business.name}
+                        </h3>
+                        <span
+                          className={cn(
+                            "shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-semibold capitalize",
+                            statusBadgeClass(business.status)
+                          )}
+                        >
+                          {business.status}
+                        </span>
+                      </div>
+                      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                        <span className="inline-flex items-center gap-1 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-[#0d241d] dark:text-gray-300">
+                          <Building2 className="h-3.5 w-3.5" />
+                          Org #{business.id}
+                        </span>
+                        {business.org_account_id ? (
+                          <span
+                            className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-md bg-gray-100 px-2 py-0.5 font-mono text-xs text-gray-500 dark:bg-[#0d241d] dark:text-gray-400"
+                            title={business.org_account_id}
+                          >
+                            <Hash className="h-3 w-3 shrink-0" />
+                            <span className="truncate">{business.org_account_id}</span>
+                          </span>
+                        ) : null}
+                      </div>
                     </div>
                   </div>
 
-                  {business.description ? (
-                    <p className="line-clamp-3 text-sm text-gray-600 dark:text-gray-300">
-                      {business.description}
-                    </p>
-                  ) : (
-                    <p className="text-sm italic text-gray-400">No description provided.</p>
-                  )}
-
-                  <div className="flex items-center gap-3 border-t border-gray-100 pt-4 dark:border-[#2f5e50]">
-                    <Button
-                      type="button"
-                      disabled={busy}
-                      onClick={() => void handleApprove(business)}
-                      className="flex-1 rounded-xl bg-emerald-600 font-semibold text-white hover:bg-emerald-700"
-                    >
-                      {busy ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
+                  {/* Body */}
+                  <div className="flex flex-1 flex-col gap-4 p-5">
+                    <div>
+                      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                        About
+                      </p>
+                      {business.description ? (
+                        <p className="line-clamp-4 text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+                          {business.description}
+                        </p>
                       ) : (
-                        <>
-                          <CheckCircle2 className="h-4 w-4" />
-                          Approve
-                        </>
+                        <p className="text-sm italic text-gray-400">No description provided.</p>
                       )}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={busy}
-                      onClick={() => {
-                        setRejectTarget(business);
-                        setRejectComment("");
-                      }}
-                      className="flex-1 rounded-xl border-red-500/40 font-semibold text-red-500 hover:bg-red-500/10 hover:text-red-400"
-                    >
-                      <XCircle className="h-4 w-4" />
-                      Reject
-                    </Button>
+                    </div>
+
+                    <div className="mt-auto grid grid-cols-2 gap-3 border-t border-gray-100 pt-4 dark:border-[#2f5e50]">
+                      <Button
+                        type="button"
+                        disabled={busy}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleApprove(business);
+                        }}
+                        className="h-11 rounded-xl bg-emerald-600 font-semibold text-white shadow-sm transition-colors hover:bg-emerald-700"
+                      >
+                        {busy ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <>
+                            <CheckCircle2 className="h-4 w-4" />
+                            Approve
+                          </>
+                        )}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={busy}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setRejectTarget(business);
+                          setRejectComment("");
+                        }}
+                        className="h-11 rounded-xl border-red-500/40 bg-red-500/5 font-semibold text-red-500 transition-colors hover:bg-red-500/15 hover:text-red-600 dark:hover:text-red-400"
+                      >
+                        <XCircle className="h-4 w-4" />
+                        Reject
+                      </Button>
+                    </div>
                   </div>
                 </CardContent>
               </Card>

--- a/frontend/src/pages/guest/Admin/AdminPendingBusinessesPage.tsx
+++ b/frontend/src/pages/guest/Admin/AdminPendingBusinessesPage.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useState } from "react";
+import { Building2, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { toast } from "sonner";
+import { apiClient } from "@/api/client";
+import type { PendingBusinessListItem } from "@/types/api";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { pageBtnPrimary, pageEmpty, pageLoader } from "@/components/layout/pageStyles";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+const PAGE_SIZE = 10;
+
+function businessInitial(name: string) {
+  return name.trim().charAt(0).toUpperCase() || "?";
+}
+
+export function AdminPendingBusinessesPage() {
+  const [businesses, setBusinesses] = useState<PendingBusinessListItem[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [page, setPage] = useState(0);
+  const [actingId, setActingId] = useState<number | null>(null);
+
+  const [rejectTarget, setRejectTarget] = useState<PendingBusinessListItem | null>(null);
+  const [rejectComment, setRejectComment] = useState("");
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const data = await apiClient.adminGetPendingBusinesses({
+          limit: PAGE_SIZE,
+          offset: page * PAGE_SIZE,
+        });
+        if (mounted) {
+          setBusinesses(data.items ?? []);
+          setTotalCount(data.total_count ?? 0);
+        }
+      } catch (err: unknown) {
+        const e = err as { response?: { data?: { error?: string } }; message?: string };
+        if (mounted) {
+          setError(
+            e?.response?.data?.error || e?.message || "Failed to load pending businesses."
+          );
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, [page]);
+
+  const removeFromList = (id: number) => {
+    setBusinesses((prev) => prev.filter((b) => b.id !== id));
+    setTotalCount((prev) => Math.max(0, prev - 1));
+  };
+
+  const handleApprove = async (business: PendingBusinessListItem) => {
+    setActingId(business.id);
+    try {
+      await apiClient.adminReviewBusiness(business.id, "verified");
+      toast.success(`"${business.name}" has been verified.`);
+      removeFromList(business.id);
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: string } }; message?: string };
+      toast.error(e?.response?.data?.error || e?.message || "Failed to verify business.");
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!rejectTarget) return;
+    const comment = rejectComment.trim();
+    if (!comment) return;
+    setActingId(rejectTarget.id);
+    try {
+      await apiClient.adminReviewBusiness(rejectTarget.id, "rejected", comment);
+      toast.success(`"${rejectTarget.name}" has been rejected.`);
+      removeFromList(rejectTarget.id);
+      setRejectTarget(null);
+      setRejectComment("");
+    } catch (err: unknown) {
+      const e = err as { response?: { data?: { error?: string } }; message?: string };
+      toast.error(e?.response?.data?.error || e?.message || "Failed to reject business.");
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+  const currentPage = page + 1;
+
+  return (
+    <PageLayout className="space-y-8">
+      <div>
+        <h1 className="mb-3 text-4xl font-bold tracking-tight text-[#1A3C34] dark:text-white md:text-5xl">
+          Admin — Verify Businesses{" "}
+          <span className="text-emerald-500 dark:text-[#98FF98]">🏢</span>
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400">
+          Review and approve business accounts awaiting verification
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+        <span className="inline-flex items-center gap-1 rounded-full border border-[#FFD700]/40 bg-[#FFD700]/10 px-3 py-1 font-semibold text-[#FFD700]">
+          {totalCount} pending
+        </span>
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm font-medium text-red-400">
+          {error}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="flex h-44 items-center justify-center">
+          <Loader2 className={cn(pageLoader, "h-10 w-10")} />
+        </div>
+      ) : businesses.length === 0 ? (
+        <div className={pageEmpty}>
+          <p className="text-xl font-bold text-[#1A3C34] dark:text-gray-200">
+            No businesses awaiting review
+          </p>
+          <p className="mt-2 text-gray-500">All caught up — nothing to verify right now.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {businesses.map((business) => {
+            const busy = actingId === business.id;
+            return (
+              <Card
+                key={business.id}
+                className="rounded-3xl border border-gray-200 bg-white shadow-sm transition-all hover:shadow-lg dark:border-[#2f5e50] dark:bg-[#163d32]"
+              >
+                <CardContent className="space-y-4 p-5">
+                  <div className="flex gap-4">
+                    <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-gray-200 bg-[#163d32] text-2xl font-bold text-[#98FF98] dark:border-[#2f5e50]">
+                      {business.avatar ? (
+                        <img
+                          src={business.avatar}
+                          alt=""
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        businessInitial(business.name)
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <h3 className="truncate text-lg font-bold text-[#1A3C34] dark:text-white">
+                        {business.name}
+                      </h3>
+                      <p className="mt-1 inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400">
+                        <Building2 className="h-3.5 w-3.5" />
+                        Org #{business.id}
+                      </p>
+                    </div>
+                  </div>
+
+                  {business.description ? (
+                    <p className="line-clamp-3 text-sm text-gray-600 dark:text-gray-300">
+                      {business.description}
+                    </p>
+                  ) : (
+                    <p className="text-sm italic text-gray-400">No description provided.</p>
+                  )}
+
+                  <div className="flex items-center gap-3 border-t border-gray-100 pt-4 dark:border-[#2f5e50]">
+                    <Button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void handleApprove(business)}
+                      className="flex-1 rounded-xl bg-emerald-600 font-semibold text-white hover:bg-emerald-700"
+                    >
+                      {busy ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <>
+                          <CheckCircle2 className="h-4 w-4" />
+                          Approve
+                        </>
+                      )}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={busy}
+                      onClick={() => {
+                        setRejectTarget(business);
+                        setRejectComment("");
+                      }}
+                      className="flex-1 rounded-xl border-red-500/40 font-semibold text-red-500 hover:bg-red-500/10 hover:text-red-400"
+                    >
+                      <XCircle className="h-4 w-4" />
+                      Reject
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {totalPages > 1 ? (
+        <div className="flex items-center justify-between border-t border-gray-200 py-6 dark:border-[#2f5e50]">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={page === 0}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            className="rounded-full"
+          >
+            Previous
+          </Button>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Page {currentPage} of {totalPages}
+          </p>
+          <Button
+            type="button"
+            className={pageBtnPrimary}
+            disabled={page >= totalPages - 1}
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+          >
+            Next →
+          </Button>
+        </div>
+      ) : null}
+
+      <Dialog
+        open={rejectTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRejectTarget(null);
+            setRejectComment("");
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Reject business</DialogTitle>
+            <DialogDescription>
+              Rejecting <span className="font-medium text-foreground">{rejectTarget?.name}</span>{" "}
+              requires a reason. It will be recorded with the review.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5">
+            <Textarea
+              placeholder="Explain why this business is being rejected…"
+              value={rejectComment}
+              onChange={(e) => setRejectComment(e.target.value)}
+              maxLength={1000}
+              rows={4}
+              autoFocus
+              className="min-h-24 resize-none"
+            />
+            <p className="text-right text-xs text-muted-foreground">
+              {rejectComment.length}/1000
+            </p>
+          </div>
+          <DialogFooter className="sm:items-center sm:justify-evenly">
+            <Button
+              type="button"
+              variant="outline"
+              className="min-w-24"
+              onClick={() => {
+                setRejectTarget(null);
+                setRejectComment("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="min-w-36 bg-red-600 text-white hover:bg-red-700 disabled:bg-red-600/40 disabled:text-white/70"
+              disabled={!rejectComment.trim() || actingId === rejectTarget?.id}
+              onClick={() => void handleReject()}
+            >
+              {actingId === rejectTarget?.id ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                "Confirm rejection"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageLayout>
+  );
+}

--- a/frontend/src/pages/guest/Admin/AdminStatisticsPage.tsx
+++ b/frontend/src/pages/guest/Admin/AdminStatisticsPage.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useState } from "react";
+import {
+  BarChart3,
+  Box,
+  Building2,
+  FileText,
+  Heart,
+  Loader2,
+  MessageSquare,
+  Shield,
+  Users,
+} from "lucide-react";
+import { apiClient } from "@/api/client";
+import type { PlatformStatistics } from "@/types/api";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { pageLoader } from "@/components/layout/pageStyles";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type Metric = {
+  label: string;
+  value: number;
+  isFloat?: boolean;
+};
+
+type Section = {
+  title: string;
+  icon: typeof Users;
+  metrics: Metric[];
+};
+
+function formatValue(value: number, isFloat?: boolean) {
+  if (value == null || Number.isNaN(value)) return "—";
+  if (isFloat) return value.toFixed(2);
+  return value.toLocaleString();
+}
+
+function buildSections(s: PlatformStatistics): Section[] {
+  return [
+    {
+      title: "Users & Accounts",
+      icon: Users,
+      metrics: [
+        { label: "Total users", value: s.total_users },
+        { label: "Admins", value: s.total_admin_users },
+        { label: "Moderators", value: s.total_moderator_users },
+        { label: "Regular users", value: s.total_regular_users },
+        { label: "Business accounts", value: s.total_business_role_users },
+        { label: "Customers", value: s.total_customers },
+      ],
+    },
+    {
+      title: "Account Status",
+      icon: Shield,
+      metrics: [
+        { label: "Active", value: s.total_active_users },
+        { label: "Muted", value: s.total_muted_users },
+        { label: "Suspended", value: s.total_suspended_users },
+      ],
+    },
+    {
+      title: "Guest Activity",
+      icon: FileText,
+      metrics: [
+        { label: "Posts", value: s.total_guest_posts },
+        { label: "Comments", value: s.total_guest_comments },
+        { label: "Post likes", value: s.total_guest_post_likes },
+        { label: "Collections", value: s.total_collections },
+        {
+          label: "Collections w/ collaborators",
+          value: s.collections_with_collaborators,
+        },
+        { label: "Posts w/ collaborators", value: s.posts_with_collaborators },
+        { label: "Avg posts / customer", value: s.avg_posts_per_customer, isFloat: true },
+        {
+          label: "Avg comments / customer",
+          value: s.avg_comments_per_customer,
+          isFloat: true,
+        },
+        { label: "Avg comments / post", value: s.avg_comments_per_post, isFloat: true },
+      ],
+    },
+    {
+      title: "Business Activity",
+      icon: Building2,
+      metrics: [
+        { label: "Org units", value: s.total_business_org_units },
+        { label: "Posts", value: s.total_business_posts },
+        { label: "Comments", value: s.total_business_comments },
+        { label: "Likes", value: s.total_business_likes },
+        { label: "Rescue boxes", value: s.total_business_boxes },
+        { label: "Box items", value: s.total_business_box_items },
+        { label: "Avg posts / business", value: s.avg_posts_per_business, isFloat: true },
+        {
+          label: "Avg comments / business",
+          value: s.avg_comments_per_business,
+          isFloat: true,
+        },
+        {
+          label: "Avg comments / post",
+          value: s.avg_business_comments_per_post,
+          isFloat: true,
+        },
+      ],
+    },
+  ];
+}
+
+const HIGHLIGHT_ICONS = [Users, FileText, Building2, Box, MessageSquare, Heart];
+
+export function AdminStatisticsPage() {
+  const [stats, setStats] = useState<PlatformStatistics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const data = await apiClient.adminGetStatistics();
+        if (mounted) setStats(data);
+      } catch (err: unknown) {
+        const e = err as { response?: { data?: { error?: string } }; message?: string };
+        if (mounted) {
+          setError(e?.response?.data?.error || e?.message || "Failed to load statistics.");
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const highlights = stats
+    ? [
+        { label: "Total users", value: stats.total_users },
+        { label: "Guest posts", value: stats.total_guest_posts },
+        { label: "Businesses", value: stats.total_business_org_units },
+        { label: "Rescue boxes", value: stats.total_business_boxes },
+        { label: "Comments", value: stats.total_guest_comments + stats.total_business_comments },
+        { label: "Likes", value: stats.total_guest_post_likes + stats.total_business_likes },
+      ]
+    : [];
+
+  return (
+    <PageLayout className="space-y-8">
+      <div>
+        <h1 className="mb-3 text-4xl font-bold tracking-tight text-[#1A3C34] dark:text-white md:text-5xl">
+          Admin — Statistics{" "}
+          <span className="text-emerald-500 dark:text-[#98FF98]">📊</span>
+        </h1>
+        <p className="text-lg text-gray-600 dark:text-gray-400">
+          All-time aggregated platform metrics
+        </p>
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm font-medium text-red-400">
+          {error}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="flex h-64 items-center justify-center">
+          <Loader2 className={cn(pageLoader, "h-12 w-12")} />
+        </div>
+      ) : !stats ? (
+        <div className="rounded-3xl border border-gray-200 bg-white p-16 text-center shadow-sm dark:border-[#2f5e50] dark:bg-[#163d32]">
+          <p className="text-xl font-bold text-[#1A3C34] dark:text-gray-200">
+            No statistics available
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+            {highlights.map((h, i) => {
+              const Icon = HIGHLIGHT_ICONS[i % HIGHLIGHT_ICONS.length];
+              return (
+                <Card
+                  key={h.label}
+                  className="rounded-3xl border border-gray-200 bg-white shadow-sm dark:border-[#2f5e50] dark:bg-[#163d32]"
+                >
+                  <CardContent className="space-y-2 p-5">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-[#2f5e50] bg-[#0d241d] text-[#98FF98]">
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <p className="text-2xl font-bold text-[#1A3C34] dark:text-white">
+                      {h.value.toLocaleString()}
+                    </p>
+                    <p className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      {h.label}
+                    </p>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            {buildSections(stats).map((section) => {
+              const Icon = section.icon;
+              return (
+                <Card
+                  key={section.title}
+                  className="rounded-3xl border border-gray-200 bg-white shadow-sm dark:border-[#2f5e50] dark:bg-[#163d32]"
+                >
+                  <CardContent className="space-y-4 p-6">
+                    <div className="flex items-center gap-2 font-semibold text-[#1A3C34] dark:text-white">
+                      <Icon size={20} className="text-emerald-500 dark:text-[#98FF98]" />
+                      <span>{section.title}</span>
+                    </div>
+                    <dl className="divide-y divide-gray-100 dark:divide-[#2f5e50]">
+                      {section.metrics.map((m) => (
+                        <div
+                          key={m.label}
+                          className="flex items-center justify-between py-2.5"
+                        >
+                          <dt className="text-sm text-gray-600 dark:text-gray-300">
+                            {m.label}
+                          </dt>
+                          <dd className="text-sm font-bold text-[#1A3C34] dark:text-white">
+                            {formatValue(m.value, m.isFloat)}
+                          </dd>
+                        </div>
+                      ))}
+                    </dl>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          <p className="flex items-center gap-2 text-sm text-gray-400">
+            <BarChart3 className="h-4 w-4" />
+            Metrics are aggregated across auth, guest, and business domains.
+          </p>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/frontend/src/pages/guest/Notifications/NotificationsPage.tsx
+++ b/frontend/src/pages/guest/Notifications/NotificationsPage.tsx
@@ -1,7 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Navigate } from "react-router-dom";
-import { Bell, Loader2 } from "lucide-react";
-import { fetchNotifications } from "@/api/notifications";
+import { Bell, Check, CheckCheck, Loader2 } from "lucide-react";
+import { fetchNotifications, markNotificationsRead } from "@/api/notifications";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { pageEmpty, pageLoader, pagePanel } from "@/components/layout/pageStyles";
@@ -9,6 +9,8 @@ import { cn } from "@/lib/utils";
 
 export function NotificationsPage() {
   const token = localStorage.getItem("token");
+
+  const queryClient = useQueryClient();
 
   const { data: notifications = [], isLoading } = useQuery({
     queryKey: ["notifications"],
@@ -18,6 +20,13 @@ export function NotificationsPage() {
     },
     enabled: !!token,
   });
+
+  const markRead = useMutation({
+    mutationFn: (ids: string[]) => markNotificationsRead(token!, ids),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["notifications"] }),
+  });
+
+  const unreadIds = notifications.filter((n) => !n.read).map((n) => n.id);
 
   if (!token) {
     return <Navigate to="/auth" replace />;
@@ -29,6 +38,20 @@ export function NotificationsPage() {
         title="Notifications"
         description="Stay up to date with your Share Bite activity"
       />
+
+      {unreadIds.length > 0 && (
+        <div className="mb-3 flex justify-end">
+          <button
+            type="button"
+            onClick={() => markRead.mutate(unreadIds)}
+            disabled={markRead.isPending}
+            className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-600 transition-colors hover:bg-emerald-500/20 disabled:opacity-50 dark:text-emerald-300"
+          >
+            <CheckCheck className="h-4 w-4" />
+            Mark all as read
+          </button>
+        </div>
+      )}
 
       {isLoading ? (
         <div className="flex h-64 items-center justify-center">
@@ -63,9 +86,22 @@ export function NotificationsPage() {
                       ? notification.metadata.message
                       : "You have a new notification")}
                 </p>
-                <span className="whitespace-nowrap text-xs text-gray-500 dark:text-gray-400">
-                  {new Date(notification.createdAt).toLocaleDateString()}
-                </span>
+                <div className="flex shrink-0 flex-col items-end gap-1.5">
+                  <span className="whitespace-nowrap text-xs text-gray-500 dark:text-gray-400">
+                    {new Date(notification.createdAt).toLocaleDateString()}
+                  </span>
+                  {!notification.read && (
+                    <button
+                      type="button"
+                      onClick={() => markRead.mutate([notification.id])}
+                      disabled={markRead.isPending}
+                      className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 transition-colors hover:text-emerald-700 disabled:opacity-50 dark:text-emerald-300 dark:hover:text-emerald-200"
+                    >
+                      <Check className="h-3.5 w-3.5" />
+                      Mark as read
+                    </button>
+                  )}
+                </div>
               </div>
             </div>
           ))}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -134,3 +134,54 @@ export interface AdminUsersParams {
   status?: string;
   sort_order?: string;
 }
+
+export interface PlatformStatistics {
+  total_users: number;
+  total_admin_users: number;
+  total_moderator_users: number;
+  total_regular_users: number;
+  total_business_role_users: number;
+  total_active_users: number;
+  total_muted_users: number;
+  total_suspended_users: number;
+  total_customers: number;
+  total_guest_posts: number;
+  total_guest_comments: number;
+  total_guest_post_likes: number;
+  total_collections: number;
+  avg_posts_per_customer: number;
+  avg_comments_per_customer: number;
+  avg_comments_per_post: number;
+  collections_with_collaborators: number;
+  posts_with_collaborators: number;
+  total_business_org_units: number;
+  total_business_posts: number;
+  total_business_comments: number;
+  total_business_likes: number;
+  total_business_boxes: number;
+  total_business_box_items: number;
+  avg_posts_per_business: number;
+  avg_comments_per_business: number;
+  avg_business_comments_per_post: number;
+}
+
+export interface PendingBusinessListItem {
+  id: number;
+  org_account_id: string;
+  name: string;
+  avatar: string;
+  description: string;
+  status: string;
+}
+
+export interface PaginatedPendingBusinesses {
+  items: PendingBusinessListItem[];
+  total_count: number;
+}
+
+export type ReviewBusinessStatus = "verified" | "rejected";
+
+export interface PaginationParams {
+  limit?: number;
+  offset?: number;
+}

--- a/internal/admin-auth/service/admin/admin_service.go
+++ b/internal/admin-auth/service/admin/admin_service.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ua-academy-projects/share-bite/internal/admin-auth/repository/user"
 	"github.com/ua-academy-projects/share-bite/pkg/database"
 	"github.com/ua-academy-projects/share-bite/pkg/logger"
-	"github.com/ua-academy-projects/share-bite/pkg/notification"
+	"github.com/ua-academy-projects/share-bite/pkg/outbox"
 )
 
 type CustomerServiceClient interface {
@@ -40,7 +40,7 @@ type service struct {
 	authRepo        user.AuthRepository
 	customerService CustomerServiceClient
 	businessService BusinessServiceClient
-	broker          notification.Publisher
+	outboxWriter    outbox.Writer
 	txManager       database.TxManager
 }
 
@@ -49,7 +49,7 @@ func NewService(
 	authRepo user.AuthRepository,
 	customerSvc CustomerServiceClient,
 	businessSvc BusinessServiceClient,
-	broker notification.Publisher,
+	outboxWriter outbox.Writer,
 	txManager database.TxManager,
 ) Service {
 	return &service{
@@ -57,7 +57,7 @@ func NewService(
 		authRepo:        authRepo,
 		customerService: customerSvc,
 		businessService: businessSvc,
-		broker:          broker,
+		outboxWriter:    outboxWriter,
 		txManager:       txManager,
 	}
 }
@@ -226,29 +226,41 @@ func (s *service) ReviewBusinessStatus(ctx context.Context, params dto.ReviewBus
 		return apperr.Wrap(http.StatusInternalServerError, "failed to complete business verification review", err)
 	}
 
-	var eventType notification.EventType
+	var eventType string
 	metadata := make(map[string]any)
 
 	if params.NewStatus == "verified" {
-		eventType = notification.BusinessVerified
+		eventType = outbox.EventTypeBusinessVerified
 		metadata["message"] = "Congratulations! Your business verification request has been successfully approved."
 	} else {
-		eventType = notification.BusinessRejected
+		eventType = outbox.EventTypeBusinessRejected
 		metadata["message"] = fmt.Sprintf("We regret to inform you that your business verification request has been rejected. Reason: %s", *params.Comment)
 	}
 
-	notificationMsg := notification.NewMessageWithMetadata(
-		eventType,
-		ownerID,
-		params.AdminID,
-		"business",
-		fmt.Sprintf("%d", params.OrgUnitID),
-		metadata,
-		time.Now(),
-	)
+	// A business can be reviewed multiple times over its lifecycle (e.g. rejected,
+	// resubmitted, then reviewed again), and each review is a distinct notification.
+	// Mix the review timestamp into the event id so repeated reviews don't collide on
+	// the notification_id UNIQUE constraint, while a single review stays idempotent
+	// across relay/consumer delivery retries (the id is stored once with the row).
+	now := time.Now().UTC()
+	entityID := fmt.Sprintf("%d", params.OrgUnitID)
+	event := outbox.Event{
+		EventType: eventType,
+		Payload: outbox.Message{
+			EventID:     outbox.NewEventID(eventType, ownerID, params.AdminID, "business", entityID, fmt.Sprintf("%d", now.UnixNano())),
+			EventType:   eventType,
+			RecipientID: ownerID,
+			ActorID:     params.AdminID,
+			EntityType:  "business",
+			EntityID:    entityID,
+			Metadata:    metadata,
+			CreatedAt:   now,
+		},
+		SourceService: outbox.DefaultSourceService,
+	}
 
-	if pubErr := s.broker.Publish(ctx, ownerID, notificationMsg); pubErr != nil {
-		logger.ErrorKV(ctx, "failed to publish review notification to redis", "org_unit_id", params.OrgUnitID, "error", pubErr.Error())
+	if err := s.outboxWriter.Enqueue(ctx, event); err != nil {
+		logger.ErrorKV(ctx, "failed to enqueue business review notification", "org_unit_id", params.OrgUnitID, "error", err.Error())
 	}
 	return nil
 }

--- a/pkg/outbox/message.go
+++ b/pkg/outbox/message.go
@@ -15,6 +15,8 @@ const (
 	EventTypeRegistrationConfirmed  = "registration_confirmed"
 	EventTypeFollowAdded            = "follow_added"
 	EventTypePasswordResetRequested = "password_reset_requested"
+	EventTypeBusinessVerified       = "business_verified"
+	EventTypeBusinessRejected       = "business_rejected"
 )
 
 type Message struct {

--- a/pkg/outbox/sns_publisher.go
+++ b/pkg/outbox/sns_publisher.go
@@ -18,7 +18,10 @@ type SNSPublisher struct {
 	topicArn string
 }
 
-func NewSNSPublisher(ctx context.Context, topicArn string) (*SNSPublisher, error) {
+// NewSNSPublisher builds an SNS publisher for topicArn. When endpointURL is
+// non-empty the SNS client targets that endpoint instead of real AWS, which is
+// how local development points the publisher at LocalStack.
+func NewSNSPublisher(ctx context.Context, topicArn, endpointURL string) (*SNSPublisher, error) {
 	if topicArn == "" {
 		return nil, fmt.Errorf("sns topic arn is required")
 	}
@@ -38,7 +41,11 @@ func NewSNSPublisher(ctx context.Context, topicArn string) (*SNSPublisher, error
 		)
 		cfg.Region = topicRegion
 	}
-	cli := sns.NewFromConfig(cfg)
+	cli := sns.NewFromConfig(cfg, func(o *sns.Options) {
+		if endpointURL != "" {
+			o.BaseEndpoint = aws.String(endpointURL)
+		}
+	})
 	return &SNSPublisher{client: cli, topicArn: topicArn}, nil
 }
 

--- a/scripts/bootstrap-localstack.sh
+++ b/scripts/bootstrap-localstack.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/bootstrap-localstack.sh
+# Provision the local SNS topic + SQS queue + filtered subscription in LocalStack,
+# mirroring terraform/main.tf (the `to_sse` subscription) for offline dev.
+#
+# Run ONCE after `docker compose -f build/compose.infra.yaml up -d localstack`.
+# Safe to re-run: topic/queue/subscription creation is idempotent.
+# =============================================================================
+
+set -euo pipefail
+
+CONTAINER="share-bite-localstack"
+REGION="us-east-2"
+ACCOUNT_ID="000000000000"
+TOPIC_NAME="notifications"
+QUEUE_NAME="notifications-sse"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Run awslocal inside the LocalStack container (addressed by name, so this works
+# regardless of which compose project started it).
+awslocal() {
+  MSYS_NO_PATHCONV=1 docker exec -i "$CONTAINER" awslocal "$@"
+}
+
+echo "==> Waiting for LocalStack to be healthy..."
+until [ "$(docker inspect -f '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null)" = "healthy" ]; do
+  sleep 1
+done
+echo -e "${GREEN}    LocalStack is healthy${RESET}"
+
+# --------------------------------------------------------------------------
+# 1. SNS topic
+# --------------------------------------------------------------------------
+echo "==> Creating SNS topic '${TOPIC_NAME}'..."
+TOPIC_ARN=$(awslocal sns create-topic --name "$TOPIC_NAME" --query 'TopicArn' --output text | tr -d '\r')
+echo -e "${GREEN}    Topic: ${TOPIC_ARN}${RESET}"
+
+# --------------------------------------------------------------------------
+# 2. SQS queue (consumed by notifications-service)
+# --------------------------------------------------------------------------
+echo "==> Creating SQS queue '${QUEUE_NAME}'..."
+awslocal sqs create-queue --queue-name "$QUEUE_NAME" >/dev/null
+QUEUE_URL=$(awslocal sqs get-queue-url --queue-name "$QUEUE_NAME" --query 'QueueUrl' --output text | tr -d '\r')
+QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url "$QUEUE_URL" \
+  --attribute-names QueueArn --query 'Attributes.QueueArn' --output text | tr -d '\r')
+echo -e "${GREEN}    Queue: ${QUEUE_URL}${RESET}"
+
+# --------------------------------------------------------------------------
+# 3. Subscription with eventType filter policy (mirrors terraform `to_sse`)
+# --------------------------------------------------------------------------
+echo "==> Subscribing queue to topic with eventType filter policy..."
+FILTER_POLICY='{"eventType":["post_liked","post_commented","post_mentioned","post_invitation_received","post_published","follow_added","business_verified","business_rejected"]}'
+
+SUB_ARN=$(awslocal sns subscribe \
+  --topic-arn "$TOPIC_ARN" \
+  --protocol sqs \
+  --notification-endpoint "$QUEUE_ARN" \
+  --return-subscription-arn --output text | tr -d '\r')
+
+# Set attributes separately — the --attributes shorthand can't carry JSON values.
+awslocal sns set-subscription-attributes \
+  --subscription-arn "$SUB_ARN" \
+  --attribute-name RawMessageDelivery --attribute-value true
+awslocal sns set-subscription-attributes \
+  --subscription-arn "$SUB_ARN" \
+  --attribute-name FilterPolicy --attribute-value "$FILTER_POLICY"
+echo -e "${GREEN}    Subscription ready (raw delivery, eventType filtered).${RESET}"
+
+# --------------------------------------------------------------------------
+# 4. Print the values to put in .env
+# --------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}================================================================${RESET}"
+echo -e "${YELLOW}  Put these in your .env (host services reach LocalStack on :4566):${RESET}"
+echo -e "${BOLD}================================================================${RESET}"
+echo ""
+echo -e "  ${CYAN}OUTBOX_SNS_TOPIC_ARN${RESET}        = ${GREEN}arn:aws:sns:${REGION}:${ACCOUNT_ID}:${TOPIC_NAME}${RESET}"
+echo -e "  ${CYAN}OUTBOX_SNS_ENDPOINT_URL${RESET}     = ${GREEN}http://localhost:4566${RESET}"
+echo -e "  ${CYAN}NOTIFICATION_SQS_QUEUE_URL${RESET}  = ${GREEN}http://localhost:4566/${ACCOUNT_ID}/${QUEUE_NAME}${RESET}"
+echo -e "  ${CYAN}NOTIFICATION_SQS_ENDPOINT_URL${RESET} = ${GREEN}http://localhost:4566${RESET}"
+echo -e "  ${CYAN}NOTIFICATION_AWS_REGION${RESET}     = ${GREEN}${REGION}${RESET}"
+echo -e "  ${CYAN}AWS_ACCESS_KEY_ID${RESET}           = ${GREEN}test${RESET}"
+echo -e "  ${CYAN}AWS_SECRET_ACCESS_KEY${RESET}       = ${GREEN}test${RESET}"
+echo ""

--- a/scripts/bootstrap-localstack.sh
+++ b/scripts/bootstrap-localstack.sh
@@ -29,7 +29,12 @@ awslocal() {
 }
 
 echo "==> Waiting for LocalStack to be healthy..."
-until [ "$(docker inspect -f '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null)" = "healthy" ]; do
+for i in $(seq 1 60); do
+  [ "$(docker inspect -f '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null)" = "healthy" ] && break
+  if [ "$i" -eq 60 ]; then
+    echo -e "${YELLOW}LocalStack did not become healthy within 60s. Is container '${CONTAINER}' running?${RESET}" >&2
+    exit 1
+  fi
   sleep 1
 done
 echo -e "${GREEN}    LocalStack is healthy${RESET}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -170,7 +170,7 @@ resource "aws_sns_topic_subscription" "to_sse" {
   raw_message_delivery = true
 
   filter_policy = jsonencode({
-    eventType = ["post_liked", "post_commented", "post_mentioned", "post_invitation_received", "post_published", "follow_added"]
+    eventType = ["post_liked", "post_commented", "post_mentioned", "post_invitation_received", "post_published", "follow_added", "business_verified", "business_rejected"]
   })
 }
 


### PR DESCRIPTION
- Add Statistics page showing aggregated platform metrics (users, account status, guest and business activity)
- Add Verify Businesses page with paginated pending list and an approve/reject review flow (rejection requires a reason)
- Wire up /admin/statistics and /admin/businesses routes and add sidebar nav links
- Map shadcn design tokens via @theme inline so popover/muted/etc. utilities render correctly (fixes transparent dialog surface)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin Statistics and Business Verification pages with protected routing, paginated pending-business review (approve/reject with required reason), and a metrics dashboard.
  * Added realtime notification updates via Server-Sent Events and “Mark all as read” actions.
* **Improvements**
  * Updated notification UI to support marking individual notifications as read and properly reflect read state from varying payloads.
* **Chores**
  * Refreshed theme token wiring for consistent light/dark utility colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->